### PR TITLE
Changed to take user program as char*, and some fix wrt review.

### DIFF
--- a/lexer.cpp
+++ b/lexer.cpp
@@ -32,10 +32,10 @@ void Lexer::TokenStream::tokeninze() {
   istringstream is{m_program};
   Token token;
 
-  // skip space
-  is >> ws;
-
   for (;;) {
+    // skip space
+    is >> ws;
+
     switch (is.peek()) {
       case 0:
         m_token_vec.push_back({Kind::end});

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -27,6 +27,10 @@ int Lexer::TokenStream::expect_number() {
   return current().lexeme_number;
 }
 
+bool Lexer::TokenStream::at_eof() {
+  return !(m_current_token_idx < m_token_vec.size());
+}
+
 void Lexer::TokenStream::tokeninze() {
   char ch;
   istringstream is{m_program};

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 
 Lexer::TokenStream::TokenStream(char* program)
-    : program{program}, current_token_idx{0} {
+    : m_program{program}, m_current_token_idx{0} {
   tokeninze();
 }
 
@@ -15,7 +15,7 @@ bool Lexer::TokenStream::consume(Lexer::Kind kind) {
   if (current().kind != kind) {
     return false;
   }
-  current_token_idx++;
+  m_current_token_idx++;
   return true;
 }
 
@@ -23,13 +23,13 @@ int Lexer::TokenStream::expect_number() {
   if (current().kind != Lexer::Kind::tk_int) {
     exit(-1);
   }
-  current_token_idx++;
+  m_current_token_idx++;
   return current().lexeme_number;
 }
 
 void Lexer::TokenStream::tokeninze() {
   char ch;
-  istringstream is{program};
+  istringstream is{m_program};
   Token token;
 
   // skip space
@@ -38,7 +38,7 @@ void Lexer::TokenStream::tokeninze() {
   for (;;) {
     switch (is.peek()) {
       case 0:
-        token_vec.push_back({Kind::end});
+        m_token_vec.push_back({Kind::end});
         return;
       case '0':
       case '1':
@@ -53,7 +53,7 @@ void Lexer::TokenStream::tokeninze() {
         // number
         token.kind = Kind::tk_int;  // TODO: ひとまずintだけ
         is >> token.lexeme_number;
-        token_vec.push_back(token);
+        m_token_vec.push_back(token);
         continue;
       default:
         // if (isalpha(ch) || ch == '_') {
@@ -75,12 +75,12 @@ void Lexer::TokenStream::tokeninze() {
         //   return current_token = {(Kind)ch};
         // }
         // unexpected
-        token_vec.push_back({Kind::end});
+        m_token_vec.push_back({Kind::end});
         return;
     }
   }
 }
 
 const Lexer::Token& Lexer::TokenStream::current() {
-  return token_vec.at(current_token_idx);
+  return m_token_vec.at(m_current_token_idx);
 }

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -3,70 +3,19 @@
 #include <cctype>
 #include <cstdlib>
 #include <iostream>
+#include <sstream>
 using namespace std;
 
-Lexer::TokenStream::TokenStream(std::istream& s)
-    : is{s}, current_token{Lexer::Kind::end} {
-  get();
+Lexer::TokenStream::TokenStream(char* program)
+    : program{program}, current_token_idx{0} {
+  tokeninze();
 }
-
-Lexer::Token Lexer::TokenStream::get() {
-  // needs impl
-  char ch;
-
-  do {  // skip space
-    if (!is.get(ch)) return current_token = {Kind::end};
-  } while (isspace(ch));
-
-  switch (ch) {
-    case 0:
-      return current_token = {Kind::end};
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-    case '8':
-    case '9':
-      // number
-      is.putback(ch);
-      is >> current_token.number_value;
-      current_token.kind = Kind::tk_int;  // TODO: ひとまずintだけ
-      return current_token;
-    default:
-      // if (isalpha(ch) || ch == '_') {
-      //   // id, reserved(TODO)
-      //   current_token.string_value = ch;
-      //   while (is.get(ch)) {
-      //     if (isalnum(ch) || ch == '_') {
-      //       current_token.string_value += ch;
-      //     } else {
-      //       is.putback(ch);
-      //       break;
-      //     }
-      //   }
-      //   current_token.kind = {Kind::tk_id};
-      //   return current_token;
-      // } else {
-      //   // TODO: literal, ==, &&, ||
-      //   // 1 char ascii symbol
-      //   return current_token = {(Kind)ch};
-      // }
-      // unexpected
-      return current_token = {Kind::end};
-  }
-}
-
-const Lexer::Token& Lexer::TokenStream::current() { return current_token; }
 
 bool Lexer::TokenStream::consume(Lexer::Kind kind) {
   if (current().kind != kind) {
     return false;
   }
-  get();
+  current_token_idx++;
   return true;
 }
 
@@ -74,7 +23,64 @@ int Lexer::TokenStream::expect_number() {
   if (current().kind != Lexer::Kind::tk_int) {
     exit(-1);
   }
-  int tmp = current().number_value;
-  get();
-  return tmp;
+  current_token_idx++;
+  return current().lexeme_number;
+}
+
+void Lexer::TokenStream::tokeninze() {
+  char ch;
+  istringstream is{program};
+  Token token;
+
+  // skip space
+  is >> ws;
+
+  for (;;) {
+    switch (is.peek()) {
+      case 0:
+        token_vec.push_back({Kind::end});
+        return;
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+        // number
+        token.kind = Kind::tk_int;  // TODO: ひとまずintだけ
+        is >> token.lexeme_number;
+        token_vec.push_back(token);
+        continue;
+      default:
+        // if (isalpha(ch) || ch == '_') {
+        //   // id, reserved(TODO)
+        //   current_token.string_value = ch;
+        //   while (is.get(ch)) {
+        //     if (isalnum(ch) || ch == '_') {
+        //       current_token.string_value += ch;
+        //     } else {
+        //       is.putback(ch);
+        //       break;
+        //     }
+        //   }
+        //   current_token.kind = {Kind::tk_id};
+        //   return current_token;
+        // } else {
+        //   // TODO: literal, ==, &&, ||
+        //   // 1 char ascii symbol
+        //   return current_token = {(Kind)ch};
+        // }
+        // unexpected
+        token_vec.push_back({Kind::end});
+        return;
+    }
+  }
+}
+
+const Lexer::Token& Lexer::TokenStream::current() {
+  return token_vec.at(current_token_idx);
 }

--- a/lexer.h
+++ b/lexer.h
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <vector>
 
 namespace Lexer {
 
@@ -27,23 +28,25 @@ enum class Kind : int {
 
 struct Token {
   Kind kind;
-  std::string string_value;
-  int number_value;
+  char* lexeme_string;
+  int len;
+  int lexeme_number;
 };
 
 class TokenStream {
  public:
-  TokenStream(std::istream &s);
+  TokenStream(char *program);
   ~TokenStream() = default;
 
-  const Token &current();
   bool consume(Kind kind);
   int expect_number();
 
  private:
-  std::istream &is;
-  Token current_token{Kind::end};
+  char *program;
+  std::vector<Token> token_vec;
+  int current_token_idx;
 
-  Token get();
+  void tokeninze();
+  const Token &current();
 };
 }  // namespace Lexer

--- a/lexer.h
+++ b/lexer.h
@@ -42,9 +42,9 @@ class TokenStream {
   int expect_number();
 
  private:
-  char *program;
-  std::vector<Token> token_vec;
-  int current_token_idx;
+  char *m_program;
+  std::vector<Token> m_token_vec;
+  int m_current_token_idx;
 
   void tokeninze();
   const Token &current();

--- a/lexer.h
+++ b/lexer.h
@@ -40,6 +40,7 @@ class TokenStream {
 
   bool consume(Kind kind);
   int expect_number();
+  bool at_eof();
 
  private:
   char *m_program;

--- a/main.cpp
+++ b/main.cpp
@@ -10,8 +10,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  std::istringstream iss{argv[1]};
-  Lexer::TokenStream ts{iss};
+  Lexer::TokenStream ts{argv[1]};
 
   cout << ".intel_syntax noprefix" << endl;
   cout << ".globl main" << endl;


### PR DESCRIPTION
- Changed to take user program as `char*`.
- Added `m_` prefix to member variables.
- Changed to tokenize first, then `consume`.
- Impled `at_eof()`.