### PR TITLE
Patch2208191449

### DIFF
--- a/gen.cpp
+++ b/gen.cpp
@@ -212,6 +212,7 @@ void gen(unique_ptr<ast::Node> node) {
       }
       // function call
       string funcname = {node->tok.lexeme_string, (unsigned long)node->tok.len};
+      print("  xor al, al\n");
       print("  call {}\n", funcname);
       print("  push rax\n");
       return;


### PR DESCRIPTION
- Changed to zero-clear `al` register before function call.
- Ucc doesn't currently support floating point. (`al` contains number of floating pointer arguments.)