### PR TITLE
Changes to call `rc_delete` when exiting a scope.

### DIFF
--- a/ast.h
+++ b/ast.h
@@ -34,6 +34,7 @@ enum class NodeKind {
   nd_lt,
   nd_le,
   nd_lval,
+  nd_lval_m_ptr,
   nd_gval,
   nd_gval_def,
 };

--- a/gen.cpp
+++ b/gen.cpp
@@ -37,11 +37,13 @@ void gen(unique_ptr<ast::Node> node) {
     case ast::NodeKind::nd_return: {
       for (int i = 0; i < node->child_vec.size(); i++) {
         gen(move(node->child_vec.at(i)));
-        if (i > 0) {
-          print("  pop r10\n");  // discard return val of rc_delete
+        if (i == 0) {
+          // r12 is callee-save (non-volatile) register.
+          // So I use this register to store return value temporally.
+          print("  pop r12\n");
         }
       }
-      print("  pop rax\n");
+      print("  mov rax, r12\n");
       print("  jmp {}\n", func_ret_label);
       return;
     }

--- a/gen.cpp
+++ b/gen.cpp
@@ -94,10 +94,16 @@ void gen(unique_ptr<ast::Node> node) {
       return;
     }
     case ast::NodeKind::nd_gval: {
+      auto type = node->type;
       gen_lval(move(node));
       // Addr of gval is on the stack top.
       print("  pop rax\n");
       print("  mov {}, [rax]\n", regax[idx_size]);
+      if (type && type->is_m_ptr()) {
+        print("  sal rax, 16\n");
+        print("  sar rax, 16\n");
+        print("  add rax, 4\n");
+      }
       print("  push rax\n");  // must be 64bit reg
       return;
     }

--- a/parser.cpp
+++ b/parser.cpp
@@ -179,7 +179,7 @@ unique_ptr<Node> Parser::stmt() {
     // return
     node = create_node(NodeKind::nd_return, expr());
     // Call to rc_delete to decrement reference counter.
-    for (auto&& node_call : create_rc_delete_calls_current_scope()) {
+    for (auto&& node_call : create_rc_delete_calls_all_scope()) {
       node->add_child(move(node_call));
     }
     m_ts.expect(';');

--- a/parser.h
+++ b/parser.h
@@ -47,4 +47,6 @@ class Parser {
   lexer::TokenStream &m_ts;
 };
 
+std::vector<std::unique_ptr<ast::Node>> create_rc_delete_calls();
+
 }  // namespace parser

--- a/parser.h
+++ b/parser.h
@@ -6,6 +6,7 @@
 
 #include "ast.h"
 #include "lexer.h"
+#include "symtable.h"
 #include "type.h"
 
 namespace parser {
@@ -47,6 +48,9 @@ class Parser {
   lexer::TokenStream &m_ts;
 };
 
-std::vector<std::unique_ptr<ast::Node>> create_rc_delete_calls();
+std::vector<std::unique_ptr<ast::Node>> create_rc_delete_calls(
+    std::vector<std::shared_ptr<symbol::Symbol>>);
+std::vector<std::unique_ptr<ast::Node>> create_rc_delete_calls_all_scope();
+std::vector<std::unique_ptr<ast::Node>> create_rc_delete_calls_current_scope();
 
 }  // namespace parser

--- a/rc_gc.c
+++ b/rc_gc.c
@@ -5,7 +5,7 @@
 // #define POC
 
 void* rc_malloc(int size) {
-  void* tmp = (void*)malloc(size + 4);
+  void* tmp = malloc(size + 4);
   set_count(tmp, 0);
   return make_defined(tmp);
 }
@@ -14,6 +14,7 @@ void rc_free(void* ptr) { free(delete_flag(ptr)); }
 
 void rc_delete(void* ptr) {
   if (!is_defined(ptr)) return;
+  // if (get_count(ptr) == 0) return;
   dec_count(ptr);
   if (get_count(ptr) == 0) {
     // TODO: Need to free children.
@@ -23,8 +24,8 @@ void rc_delete(void* ptr) {
 }
 
 void rc_update(void** dst, void* src) {
-  rc_delete(*dst);
   inc_count(src);
+  rc_delete(*dst);
   *dst = src;
 }
 
@@ -64,7 +65,7 @@ void* delete_flag(void* ptr) {
 
 #ifdef POC
 int main(int argc, char* argv[]) {
-  void *mptr, *tmp;
+  void* mptr;
   for (;;) {
     rc_update(&mptr, rc_malloc(1024));
   }

--- a/symtable.cpp
+++ b/symtable.cpp
@@ -43,6 +43,18 @@ shared_ptr<Symbol> find_symbol(shared_ptr<Symbol> symbol,
   }
 }
 
+std::vector<std::shared_ptr<Symbol>> find_all_symbol(
+    std::shared_ptr<Symbol> symbol, type::Kind kind) {
+  vector<shared_ptr<symbol::Symbol>> v;
+  while (symbol) {
+    if (symbol->type->is_kind_of(kind)) {
+      v.push_back(symbol);
+    }
+    symbol = symbol->next;
+  }
+  return v;
+}
+
 int size(shared_ptr<Symbol> symbol) {
   if (symbol == nullptr) {
     return 0;
@@ -70,16 +82,17 @@ shared_ptr<Symbol> SymTable::find_local_current_scope(
   return find_symbol(local_current(), token);
 }
 
-vector<shared_ptr<symbol::Symbol>> SymTable::find_all_mptr_in_current_scope() {
-  vector<shared_ptr<symbol::Symbol>> v;
-  auto current_symbol = local_current();
-  while (current_symbol) {
-    if (current_symbol->type->is_m_ptr()) {
-      v.push_back(current_symbol);
-    }
-    current_symbol = current_symbol->next;
+std::vector<std::shared_ptr<symbol::Symbol>> SymTable::find_all_mptr() {
+  vector<shared_ptr<Symbol>> v_ret;
+  for (auto i = m_local.size() - 1; i != -1; i--) {
+    auto v = find_all_symbol(m_local.at(i), type::Kind::type_m_ptr);
+    v_ret.insert(v_ret.end(), v.begin(), v.end());
   }
-  return v;
+  return v_ret;
+}
+
+vector<shared_ptr<symbol::Symbol>> SymTable::find_all_mptr_in_current_scope() {
+  return find_all_symbol(local_current(), type::Kind::type_m_ptr);
 }
 
 shared_ptr<Symbol> SymTable::register_local(

--- a/symtable.cpp
+++ b/symtable.cpp
@@ -70,6 +70,18 @@ shared_ptr<Symbol> SymTable::find_local_current_scope(
   return find_symbol(local_current(), token);
 }
 
+vector<shared_ptr<symbol::Symbol>> SymTable::find_all_mptr_in_current_scope() {
+  vector<shared_ptr<symbol::Symbol>> v;
+  auto current_symbol = local_current();
+  while (current_symbol) {
+    if (current_symbol->type->is_m_ptr()) {
+      v.push_back(current_symbol);
+    }
+    current_symbol = current_symbol->next;
+  }
+  return v;
+}
+
 shared_ptr<Symbol> SymTable::register_local(
     pair<lexer::Token, shared_ptr<type::Type>> tok_type_pair) {
   auto [tok, type] = tok_type_pair;

--- a/symtable.h
+++ b/symtable.h
@@ -47,6 +47,7 @@ class SymTable {
   std::shared_ptr<symbol::Symbol> find_local(const lexer::Token &token);
   std::shared_ptr<symbol::Symbol> find_local_current_scope(
       const lexer::Token &token);
+  std::vector<std::shared_ptr<symbol::Symbol>> find_all_mptr_in_current_scope();
   std::shared_ptr<symbol::Symbol> register_local(
       std::pair<lexer::Token, std::shared_ptr<type::Type>>);
   std::shared_ptr<symbol::Symbol> find_global(const lexer::Token &token);

--- a/symtable.h
+++ b/symtable.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "lexer.h"
+#include "type.h"
 
 namespace symbol {
 
@@ -33,6 +34,8 @@ std::shared_ptr<Symbol> add_symbol(std::shared_ptr<Symbol>,
                                    std::shared_ptr<Symbol>);
 std::shared_ptr<Symbol> find_symbol(std::shared_ptr<Symbol> symbol,
                                     const lexer::Token &tok);
+std::vector<std::shared_ptr<Symbol>> find_all_symbol(
+    std::shared_ptr<Symbol> symbol, type::Kind kind);
 int size(std::shared_ptr<Symbol>);
 
 class SymTable {
@@ -47,6 +50,7 @@ class SymTable {
   std::shared_ptr<symbol::Symbol> find_local(const lexer::Token &token);
   std::shared_ptr<symbol::Symbol> find_local_current_scope(
       const lexer::Token &token);
+  std::vector<std::shared_ptr<symbol::Symbol>> find_all_mptr();
   std::vector<std::shared_ptr<symbol::Symbol>> find_all_mptr_in_current_scope();
   std::shared_ptr<symbol::Symbol> register_local(
       std::pair<lexer::Token, std::shared_ptr<type::Type>>);

--- a/test.sh
+++ b/test.sh
@@ -95,6 +95,6 @@ assert 24 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); @a = 24;
 assert 10 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); a = rc_malloc(4); @a = 10; return @a;}' './rc_gc.c'  # only 8 bytes leaks
 assert 11 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); @a = 2; a = rc_malloc(4); @a = 11; return @a;}' './rc_gc.c'  # only 8 bytes leaks
 assert 12 'int @rc_malloc(int a); int main() {{int @a; a = rc_malloc(4);} return 12;}' './rc_gc.c'
-assert 12 'int @rc_malloc(int a); int main() {{int @a; a = rc_malloc(4); return 12;}}' './rc_gc.c'
+assert 12 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); {return 12;}}' './rc_gc.c'
 
 echo OK

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ assert() {
 	if [ "$#" = 3 ]; then
 		if [[ -e "$3" ]]; then
 			cc -c "$3"
-			cc -o tmp tmp.s "${3/.c/.o}"
+			cc -o tmp tmp.s "${3/.c/.o}" -fsanitize=leak
 		else
 			echo "$3" >tmp_lib.c
 			cc -c tmp_lib.c
@@ -94,5 +94,7 @@ assert 23 'int a[10]; int main() {a[0] = 23; return a[0];}'
 assert 24 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); @a = 24; return @a;}' './rc_gc.c'
 assert 10 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); a = rc_malloc(4); @a = 10; return @a;}' './rc_gc.c'  # only 8 bytes leaks
 assert 11 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); @a = 2; a = rc_malloc(4); @a = 11; return @a;}' './rc_gc.c'  # only 8 bytes leaks
+assert 12 'int @rc_malloc(int a); int main() {{int @a; a = rc_malloc(4);} return 12;}' './rc_gc.c'
+assert 12 'int @rc_malloc(int a); int main() {{int @a; a = rc_malloc(4); return 12;}}' './rc_gc.c'
 
 echo OK

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,7 @@ assert() {
 		if [[ -e "$3" ]]; then
 			cc -c "$3"
 			cc -o tmp tmp.s "${3/.c/.o}" -fsanitize=leak
+			# cc -o tmp tmp.s "${3/.c/.o}"
 		else
 			echo "$3" >tmp_lib.c
 			cc -c tmp_lib.c
@@ -92,9 +93,15 @@ assert 0 'int a; int main() {return a;}'
 assert 10 'int a; int main() {a = 10; return a;}'
 assert 23 'int a[10]; int main() {a[0] = 23; return a[0];}'
 assert 24 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); @a = 24; return @a;}' './rc_gc.c'
-assert 10 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); a = rc_malloc(4); @a = 10; return @a;}' './rc_gc.c'  # only 8 bytes leaks
-assert 11 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); @a = 2; a = rc_malloc(4); @a = 11; return @a;}' './rc_gc.c'  # only 8 bytes leaks
+assert 10 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); a = rc_malloc(4); @a = 10; return @a;}' './rc_gc.c'         # only 8 bytes leaks
+assert 11 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); @a = 2; a = rc_malloc(4); @a = 11; return @a;}' './rc_gc.c' # only 8 bytes leaks
 assert 12 'int @rc_malloc(int a); int main() {{int @a; a = rc_malloc(4);} return 12;}' './rc_gc.c'
-assert 12 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); {return 12;}}' './rc_gc.c'
+assert 13 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); {return 13;}}' './rc_gc.c'
+assert 14 'int @rc_malloc(int a); int main() {int @a; {a = rc_malloc(4);} return 14;}' './rc_gc.c'
+assert 24 'int @rc_malloc(int a); int main() {int @a; a = rc_malloc(4); a = a; @a = 24; return @a;}' './rc_gc.c'
+assert 10 'int @rc_malloc(int a); int main() { int i; int @a; for(i = 0; i < 1024; i+=1) { a = rc_malloc(1024 * 1024 * 1024); } return 10; }' './rc_gc.c'
+# assert 11 'int @rc_malloc(int a); int main() { int i; int @ptr; for (;;) { ptr = rc_malloc(4 * 1024); } return 11;}' './rc_gc.c'
+assert 11 'int @rc_malloc(int a); int main() { int i; for (i = 0; i < 1024; i+=1) { int @ptr; ptr = rc_malloc(4 * 1024); } return 11; }' './rc_gc.c'
+assert 12 'int @rc_malloc(int a); int @a; int main() {a = rc_malloc(4); @a = 12; return @a;}' './rc_gc.c'
 
 echo OK


### PR DESCRIPTION
Implemented scope-related stuff.

```c
int @rc_malloc(int a);
int main() {
  int @a;
  a = rc_malloc(4);  // (1): Actually allocates additional 4 bytes for counter
  a = rc_malloc(4);  // (2): Same as above
  @a = 10;
  return @a;
}
```

Now memory region allocated in (1) and (2) is automatically freed.